### PR TITLE
add compile option for truncate3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ option(USE_AES_NI "Compile with AES NI" ON)
 
 option(USE_OPENMP "Compile with OpenMP" ON)
 
+option(USE_ABY3_TRUNC1 "Compile with ABY3 truncate 1 algorithm" OFF)
+
 ########################### the project build part ###############################
 message(STATUS "Using paddlepaddle installation of ${paddle_version}")
 message(STATUS "paddlepaddle include directory: ${PADDLE_INCLUDE}")
@@ -83,6 +85,10 @@ if (USE_OPENMP)
     add_compile_options(-fopenmp)
     find_package(OpenMP REQUIRED)
 endif(USE_OPENMP)
+
+if (USE_ABY3_TRUNC1)
+    add_compile_definitions(USE_ABY3_TRUNC1)
+endif(USE_ABY3_TRUNC1)
 
 add_subdirectory(core/privc3)
 add_subdirectory(core/paddlefl_mpc/mpc_protocol)

--- a/core/privc3/fixedpoint_tensor.h
+++ b/core/privc3/fixedpoint_tensor.h
@@ -191,6 +191,9 @@ public:
     void max_pooling(FixedPointTensor* ret,
                      BooleanTensor<T>* pos = nullptr) const;
 
+    static void truncate(const FixedPointTensor* op, FixedPointTensor* ret,
+                        size_t scaling_factor);
+
 private:
 
     static inline std::shared_ptr<CircuitContext> aby3_ctx() {
@@ -200,9 +203,6 @@ private:
     static inline std::shared_ptr<TensorAdapterFactory> tensor_factory() {
         return paddle::mpc::ContextHolder::tensor_factory();
     }
-
-    static void truncate(const FixedPointTensor* op, FixedPointTensor* ret,
-                          size_t scaling_factor);
 
     template<typename MulFunc>
     static void mul_trunc(const FixedPointTensor<T, N>* lhs,

--- a/core/privc3/fixedpoint_tensor_imp.h
+++ b/core/privc3/fixedpoint_tensor_imp.h
@@ -247,11 +247,7 @@ void FixedPointTensor<T, N>::truncate(const FixedPointTensor<T, N>* op,
         }
         // r'
         aby3_ctx()->template gen_random_private(*temp[0]);
-        std::for_each(temp[0]->data(), temp[0]->data() + temp[0]->numel(),
-                      [] (T& a) {
-                          a = (T) (a * std::pow(2, sizeof(T) * 8 - 2)
-                                   / std::numeric_limits<T>::max());
-                      });
+        temp[0]->rshift(1, temp[0].get());
 
         //r'_0, r'_1
         aby3_ctx()->template gen_random_private(*temp[1]);

--- a/core/privc3/fixedpoint_tensor_imp.h
+++ b/core/privc3/fixedpoint_tensor_imp.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <limits>
 #include <memory>
 #include <algorithm>
 

--- a/core/privc3/fixedpoint_tensor_test.cc
+++ b/core/privc3/fixedpoint_tensor_test.cc
@@ -3438,7 +3438,7 @@ TEST_F(FixedTensorTest, inv_sqrt_test) {
 }
 
 #ifdef USE_ABY3_TRUNC1 //use aby3 trunc1
-TEST_F(FixedTensorTest, truncate1_msb_failed) {
+TEST_F(FixedTensorTest, truncate1_msb_incorrect) {
     std::vector<size_t> shape = { 1 };
     std::shared_ptr<TensorAdapter<int64_t>> sl[3] = { gen(shape), gen(shape), gen(shape) };
     std::shared_ptr<TensorAdapter<int64_t>> sout[6] = { gen(shape), gen(shape), gen(shape),
@@ -3498,7 +3498,7 @@ TEST_F(FixedTensorTest, truncate1_msb_failed) {
 }
 
 #else
-TEST_F(FixedTensorTest, truncate3_msb_not_failed) {
+TEST_F(FixedTensorTest, truncate3_msb_correct) {
     std::vector<size_t> shape = { 1 };
     std::shared_ptr<TensorAdapter<int64_t>> sl[3] = { gen(shape), gen(shape), gen(shape) };
     std::shared_ptr<TensorAdapter<int64_t>> sout[6] = { gen(shape), gen(shape), gen(shape),

--- a/core/privc3/fixedpoint_tensor_test.cc
+++ b/core/privc3/fixedpoint_tensor_test.cc
@@ -3437,4 +3437,124 @@ TEST_F(FixedTensorTest, inv_sqrt_test) {
 
 }
 
+#ifdef USE_ABY3_TRUNC1 //use aby3 trunc1
+TEST_F(FixedTensorTest, truncate1_msb_failed) {
+    std::vector<size_t> shape = { 1 };
+    std::shared_ptr<TensorAdapter<int64_t>> sl[3] = { gen(shape), gen(shape), gen(shape) };
+    std::shared_ptr<TensorAdapter<int64_t>> sout[6] = { gen(shape), gen(shape), gen(shape),
+                                                        gen(shape), gen(shape), gen(shape)};
+    // lhs = 6 = 1 + 2 + 3, share before truncate
+    // zero share 0 = (1 << 62) + (1 << 62) - (1 << 63)
+    sl[0]->data()[0] = ((int64_t) 3 << 32) - ((uint64_t) 1 << 63);
+    sl[1]->data()[0] = ((int64_t) 2 << 32) + ((int64_t) 1 << 62);
+    sl[2]->data()[0] = ((int64_t) 1 << 32) + ((int64_t) 1 << 62);
+
+    auto pr = gen(shape);
+
+    // rhs = 15
+    pr->data()[0] = 6 << 16;
+    pr->scaling_factor() = 16;
+    Fix64N16 fl0(sl[0].get(), sl[1].get());
+    Fix64N16 fl1(sl[1].get(), sl[2].get());
+    Fix64N16 fl2(sl[2].get(), sl[0].get());
+    Fix64N16 fout0(sout[0].get(), sout[1].get());
+    Fix64N16 fout1(sout[2].get(), sout[3].get());
+    Fix64N16 fout2(sout[4].get(), sout[5].get());
+
+    auto p = gen(shape);
+
+    _t[0] = std::thread(
+        [&] () {
+        g_ctx_holder::template run_with_context(
+            _exec_ctx.get(), _mpc_ctx[0], [&](){
+                Fix64N16::truncate(&fl0, &fout0, 16);
+                fout0.reveal_to_one(0, p.get());
+            });
+        }
+    );
+    _t[1] = std::thread(
+        [&] () {
+        g_ctx_holder::template run_with_context(
+            _exec_ctx.get(), _mpc_ctx[1], [&](){
+                Fix64N16::truncate(&fl1, &fout1, 16);
+                fout1.reveal_to_one(0, nullptr);
+            });
+        }
+    );
+    _t[2] = std::thread(
+        [&] () {
+        g_ctx_holder::template run_with_context(
+            _exec_ctx.get(), _mpc_ctx[2], [&](){
+                Fix64N16::truncate(&fl2, &fout2, 16);
+                fout2.reveal_to_one(0, nullptr);
+            });
+        }
+    );
+    for (auto &t: _t) {
+        t.join();
+    }
+    // failed: result is not close to 6
+    EXPECT_GT(std::abs((p->data()[0] >> 16) - 6), 1000);
+}
+
+#else
+TEST_F(FixedTensorTest, truncate3_msb_not_failed) {
+    std::vector<size_t> shape = { 1 };
+    std::shared_ptr<TensorAdapter<int64_t>> sl[3] = { gen(shape), gen(shape), gen(shape) };
+    std::shared_ptr<TensorAdapter<int64_t>> sout[6] = { gen(shape), gen(shape), gen(shape),
+                                                        gen(shape), gen(shape), gen(shape)};
+    // lhs = 6 = 1 + 2 + 3, share before truncate
+    // zero share 0 = (1 << 62) + (1 << 62) - (1 << 63)
+    sl[0]->data()[0] = ((int64_t) 3 << 32) - ((uint64_t) 1 << 63);
+    sl[1]->data()[0] = ((int64_t) 2 << 32) + ((int64_t) 1 << 62);
+    sl[2]->data()[0] = ((int64_t) 1 << 32) + ((int64_t) 1 << 62);
+
+    auto pr = gen(shape);
+
+    // rhs = 15
+    pr->data()[0] = 6 << 16;
+    pr->scaling_factor() = 16;
+    Fix64N16 fl0(sl[0].get(), sl[1].get());
+    Fix64N16 fl1(sl[1].get(), sl[2].get());
+    Fix64N16 fl2(sl[2].get(), sl[0].get());
+    Fix64N16 fout0(sout[0].get(), sout[1].get());
+    Fix64N16 fout1(sout[2].get(), sout[3].get());
+    Fix64N16 fout2(sout[4].get(), sout[5].get());
+
+    auto p = gen(shape);
+
+    _t[0] = std::thread(
+        [&] () {
+        g_ctx_holder::template run_with_context(
+            _exec_ctx.get(), _mpc_ctx[0], [&](){
+                Fix64N16::truncate(&fl0, &fout0, 16);
+                fout0.reveal_to_one(0, p.get());
+            });
+        }
+    );
+    _t[1] = std::thread(
+        [&] () {
+        g_ctx_holder::template run_with_context(
+            _exec_ctx.get(), _mpc_ctx[1], [&](){
+                Fix64N16::truncate(&fl1, &fout1, 16);
+                fout1.reveal_to_one(0, nullptr);
+            });
+        }
+    );
+    _t[2] = std::thread(
+        [&] () {
+        g_ctx_holder::template run_with_context(
+            _exec_ctx.get(), _mpc_ctx[2], [&](){
+                Fix64N16::truncate(&fl2, &fout2, 16);
+                fout2.reveal_to_one(0, nullptr);
+            });
+        }
+    );
+    for (auto &t: _t) {
+        t.join();
+    }
+    EXPECT_EQ((p->data()[0] >> 16), 6);
+}
+#endif
+
 } // namespace aby3

--- a/core/privc3/fixedpoint_tensor_test.cc
+++ b/core/privc3/fixedpoint_tensor_test.cc
@@ -1267,6 +1267,7 @@ TEST_F(FixedTensorTest, mulfixed) {
     EXPECT_TRUE(test_fixedt_check_tensor_eq(out0.get(), &result));
 }
 
+#ifndef USE_ABY3_TRUNC1 //use aby3 trunc1
 TEST_F(FixedTensorTest, mulfixed_multi_times) {
 
     std::vector<size_t> shape = {100000, 1};
@@ -1327,6 +1328,7 @@ TEST_F(FixedTensorTest, mulfixed_multi_times) {
     EXPECT_TRUE(test_fixedt_check_tensor_eq(out1.get(), out2.get()));
     EXPECT_TRUE(test_fixedt_check_tensor_eq(out0.get(), &result));
 }
+#endif
 
 TEST_F(FixedTensorTest, mulfixed_overflow) {
 


### PR DESCRIPTION
为truncate3添加编译选项USE_ABY3_TRUNC1, 默认OFF。默认使用truncate3,设置On则使用aby3得truncate1。