### PR TITLE
Fix dir creation race condition bug in examples

### DIFF
--- a/python/paddle_fl/mpc/examples/lenet_with_mnist/train_lenet.py
+++ b/python/paddle_fl/mpc/examples/lenet_with_mnist/train_lenet.py
@@ -17,6 +17,7 @@ MNIST CNN Demo (LeNet5)
 
 import sys
 import os
+import errno
 import numpy as np
 import time
 import logging
@@ -117,7 +118,12 @@ def infer():
     """
     mpc_infer_data_dir = "./mpc_infer_data/"
     if not os.path.exists(mpc_infer_data_dir):
-        os.mkdir(mpc_infer_data_dir)
+        try:
+            os.mkdir(mpc_infer_data_dir)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+
     prediction_file = mpc_infer_data_dir + "mnist_debug_prediction"
     prediction_file_part = prediction_file + ".part{}".format(role)
 

--- a/python/paddle_fl/mpc/examples/logistic_with_mnist/train_fc_sigmoid.py
+++ b/python/paddle_fl/mpc/examples/logistic_with_mnist/train_fc_sigmoid.py
@@ -17,6 +17,7 @@ MNIST Demo
 
 import sys
 import os
+import errno
 
 import numpy as np
 import time
@@ -99,9 +100,15 @@ print('Mpc Training of Epoch={} Batch_size={}, epoch_cost={:.4f} s'
       .format(epoch_num, BATCH_SIZE, (end_time - start_time)))
 
 # prediction
+
 mpc_infer_data_dir = "./mpc_infer_data/"
 if not os.path.exists(mpc_infer_data_dir):
-    os.mkdir(mpc_infer_data_dir)
+    try:
+        os.mkdir(mpc_infer_data_dir)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
 prediction_file = mpc_infer_data_dir + "mnist_debug_prediction.part{}".format(role)
 if os.path.exists(prediction_file):
     os.remove(prediction_file)

--- a/python/paddle_fl/mpc/examples/logistic_with_mnist/train_fc_softmax.py
+++ b/python/paddle_fl/mpc/examples/logistic_with_mnist/train_fc_softmax.py
@@ -17,6 +17,8 @@ MNIST CNN Demo (LeNet5)
 
 import sys
 import os
+import errno
+
 import numpy as np
 import time
 import logging
@@ -91,7 +93,12 @@ def infer():
     """
     mpc_infer_data_dir = "./mpc_infer_data/"
     if not os.path.exists(mpc_infer_data_dir):
-        os.mkdir(mpc_infer_data_dir)
+        try:
+            os.mkdir(mpc_infer_data_dir)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+
     prediction_file = mpc_infer_data_dir + "mnist_debug_prediction"
     prediction_file_part = prediction_file + ".part{}".format(role)
 


### PR DESCRIPTION
Multiple processes create the same dir in standalone mode may cause race condition. The patch fixes this by catch the error and ignore.