### PR TITLE
fix bugs of grpc mode.

### DIFF
--- a/core/paddlefl_mpc/mpc_protocol/network/mesh_network_grpc.cc
+++ b/core/paddlefl_mpc/mpc_protocol/network/mesh_network_grpc.cc
@@ -26,7 +26,7 @@ void GrpcBuffer::write_buffer(const size_t party_id, const std::string data) {
     }
 
     buffer[party_id].push(data);
-    if (buffer[party_id].size() == BUFFER_LENGTH) {
+    if (buffer[party_id].size() == 1) {
         read_cv.notify_all();
     }
 }
@@ -50,9 +50,9 @@ void TransportClient::send(const int party_id, const void* data, size_t size) {
     request.set_data(data, size);
 
     transport::GrpcReply reply;
-    grpc::ClientContext context;
 
     for (size_t i = 0; i < _max_retry; ++i) {
+        grpc::ClientContext context;
         grpc::Status status = stub_->send_data(&context, request, &reply);
         if (status.ok()) {
             return;

--- a/core/paddlefl_mpc/mpc_protocol/network/mesh_network_grpc.h
+++ b/core/paddlefl_mpc/mpc_protocol/network/mesh_network_grpc.h
@@ -42,7 +42,7 @@ class GrpcBuffer {
         void read_buffer(const size_t party_id, std::string& data);
 
     private:
-        static const int BUFFER_LENGTH = 1; // this version only supports BUFFER_LENGTH = 1.
+        static const int BUFFER_LENGTH = 65535; // this version only supports BUFFER_LENGTH = 1.
         static const int MAX_NET_SIZE = 3;
         std::vector<std::queue<std::string>> buffer;
 
@@ -94,6 +94,7 @@ class MeshNetworkGrpc : public paddle::mpc::AbstractNetwork, public transport::T
         // gRPC server: start server to listen
         void run_server(const std::string& server_address) {
             grpc::ServerBuilder builder;
+            builder.SetMaxMessageSize(INT_MAX);
             builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
             builder.RegisterService(this);
             server = builder.BuildAndStart();


### PR DESCRIPTION
fix bugs of grpc model:
1. hang when using softmax.
2. "assertion failed: call_ == nullptr" when using conv2d.