### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+opencv-python==4.2.0.32
+paddlepaddle==1.8.5
+paddle-serving-client==0.4.0
+zmq


### PR DESCRIPTION
Add requirements.txt for depicting dependencies. Using different versions of paddlepaddle or paddle-serving-client, the examples won't be able to run.