### PR TITLE
fix path error

### DIFF
--- a/python/paddle_fl/paddle_fl/examples/secagg_demo/fl_trainer.py
+++ b/python/paddle_fl/paddle_fl/examples/secagg_demo/fl_trainer.py
@@ -26,7 +26,7 @@ import hashlib
 import hmac
 
 logging.basicConfig(
-    filename="log/test.log",
+    filename="logs/test.log",
     filemode="w",
     format="%(asctime)s %(name)s:%(levelname)s:%(message)s",
     datefmt="%d-%M-%Y %H:%M:%S",


### PR DESCRIPTION
If there is no directory named "log", the old path will cause an error. But before running this code, the directory "logs" will be automatically created in other codes.